### PR TITLE
Scollable drop down list

### DIFF
--- a/leonardo/static/css/leonardo.css
+++ b/leonardo/static/css/leonardo.css
@@ -26,3 +26,9 @@ img.no-resize {
 .td-padded {
     padding: 3px;
 }
+
+.dropdown-menu {
+    max-height:     600px;
+    overflow:       hidden;
+    overflow-y:     auto;
+}


### PR DESCRIPTION
When a dashboard drop down list has _a lot_ of dashboards available, it's awkward to scroll down the page to find the desired dashboard.  This code adds a vertical scroll bar inside the drop down list.
