### PR TITLE
Set config to use an absolute path

### DIFF
--- a/leonardo/config.py
+++ b/leonardo/config.py
@@ -7,6 +7,6 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 DEBUG = True
 SECRET_KEY = 'MY_SECRET_KEY'
 
-with open("config/leonardo.yaml" ) as config_file:
+with open(basedir + "/../config/leonardo.yaml") as config_file:
      YAML_CONFIG = yaml.load( config_file.read() )
 


### PR DESCRIPTION
Apache gets confused on where to load the config
file without this patch.
