### PR TITLE
Allow override of config location with CONFIG_FILE

### DIFF
--- a/leonardo/config.py
+++ b/leonardo/config.py
@@ -5,8 +5,10 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 
 
 DEBUG = True
-SECRET_KEY = 'MY_SECRET_KEY'
+SECRET_KEY = os.environ.get('SECRET_KEY', 'MY_SECRET_KEY')
+config_filename = os.environ.get('CONFIG_FILE',
+                                 basedir + "/../config/leonardo.yaml")
 
-with open(basedir + "/../config/leonardo.yaml") as config_file:
+with open(config_filename) as config_file:
      YAML_CONFIG = yaml.load( config_file.read() )
 


### PR DESCRIPTION
When running Leonardo as WSGI or packaging it, it is convenient to be able to overrider the config location to be something other than relative to the binary.   This patch allows specifying CONFIG_FILE in the environment (os.environ) to specify a different config file; default is still relative to the binary.
