### PR TITLE
Add 'field_order' property to set field order

### DIFF
--- a/leonardo/graph.py
+++ b/leonardo/graph.py
@@ -80,6 +80,8 @@ class GraphiteGraph:
             self.targets[field] = self.yaml_spec['fields'][field]
             self.target_order.append(field)
 
+        if 'field_order' in self.yaml_spec:
+            self.target_order = self.yaml_spec['field_order']
 
 
     def get_graph_spec(self):


### PR DESCRIPTION
yaml.load does not preserve field order in original file (see: http://pyyaml.org/ticket/29), so Leonardo uses the field order provided by the dict's hashing algorithm.   For some graphs it is very helpful to specify the field order precisely.  This patch adds a 'field_order' property to allow an ordered list to specify the order.  For example:

field_order: 
    - nice
    - user
    - irq
    - softirq
    - steal
    - guest
    - system
    - iowait

Default is still "field order provided by dict's hashing algorithm", but it may be worth making the default order "alphabetically sorted".
