### PR TITLE
Fix URL root assumption in decoding path from cookie

### DIFF
--- a/leonardo/views/frontend.py
+++ b/leonardo/views/frontend.py
@@ -19,7 +19,7 @@ def index():
 
     favorite_dashboard = request.cookies.get('favorite')
     if favorite_dashboard is not None:
-        category, dash = filter(None, urllib.unquote(favorite_dashboard).split('/'))
+        category, dash = filter(None, urllib.unquote(favorite_dashboard).split('/'))[-2:]
         app.logger.debug('Redirect to favorite dashboard /%s/%s' % (category, dash) )
         return redirect( url_for('dash', category = category, dash = dash) )
 


### PR DESCRIPTION
The favorite cookie contains the entire request path, but this code assumes that Leonardo is on the root path of the web server.  Fixed to only pull out the final two path components, which is the part under Leo's control.