### PR TITLE
add proxy for graphite requests + fix

### DIFF
--- a/config/leonardo.yaml.example
+++ b/config/leonardo.yaml.example
@@ -1,5 +1,6 @@
 graphite: http://graphite.example.com
 templatedir: graphs
+proxy_graphite: true
 #:username: admin
 #:password: secret
 logging:

--- a/leonardo/category.py
+++ b/leonardo/category.py
@@ -4,9 +4,8 @@ from .dashboard import Dashboard
 
 
 class Category:
-    def __init__(self, graphite_base, render_url, graph_templates, name,  options={}):
-        self.graphite_base = graphite_base
-        self.graphite_render = self.graphite_base + "/render/"
+    def __init__(self, graphite_render, graph_templates, name,  options={}):
+        self.graphite_render = graphite_render
         self.graph_templates = graph_templates
         self.name = name
         self.dash_templates = "%s/%s" % (graph_templates, name)

--- a/leonardo/leonardo.py
+++ b/leonardo/leonardo.py
@@ -4,7 +4,6 @@ from . import category
 from . import config
 from time import strftime, localtime
 
-
 class Leonardo(object):
     ''' 
     Top level Class that defines the initial configuration of Leonard
@@ -31,8 +30,14 @@ class Leonardo(object):
         # where graphite lives
         self.graphite_base = config.YAML_CONFIG.get('graphite')
 
+        # proxy graphite or go directly?
+        self.proxy_graphite = config.YAML_CONFIG.get('proxy_graphite', False)
+
         # where the graphite renderer is
-        self.graphite_render = "%s/render/" % self.graphite_base
+        if self.proxy_graphite:
+          self.graphite_render = "/_graphite/" 
+        else:
+          self.graphite_render = "%s/render/" % self.graphite_base
 
         # where to find graph, dash etc templates
         self.graph_templates = config.YAML_CONFIG.get('templatedir')
@@ -70,8 +75,7 @@ class Leonardo(object):
 
             if os.listdir( os.path.join(self.graph_templates,category_name) ) != []:
 
-                self.top_level[category_name] = category.Category( self.graphite_base,
-                                                              "/render/",
+                self.top_level[category_name] = category.Category( self.graphite_render,
                                                               self.graph_templates,
                                                               category_name,
                                                               { "width" : self.graph_width,

--- a/leonardo/views/__init__.py
+++ b/leonardo/views/__init__.py
@@ -3,3 +3,4 @@ from . import api
 from . import errors
 from . import search
 from . import multiple
+from . import proxy

--- a/leonardo/views/frontend.py
+++ b/leonardo/views/frontend.py
@@ -19,7 +19,7 @@ def index():
 
     favorite_dashboard = request.cookies.get('favorite')
     if favorite_dashboard is not None:
-        category, dash = filter(None, urllib.parse.unquote(favorite_dashboard).split('/'))[-2:]
+        category, dash = list(filter(None, urllib.parse.unquote(favorite_dashboard).split('/')))[-2:]
         app.logger.debug('Redirect to favorite dashboard /%s/%s' % (category, dash) )
         return redirect( url_for('dash', category = category, dash = dash) )
 

--- a/leonardo/views/proxy.py
+++ b/leonardo/views/proxy.py
@@ -1,0 +1,27 @@
+from flask import request, render_template, Response
+from ..leonardo import Leonardo
+from .. import app
+from urllib.parse import urlparse, urlunparse
+import requests
+
+@app.route('/_graphite/', methods=["GET"])
+def proxy():
+  leonardo = Leonardo()
+
+  graph_render = "%s/render/" % leonardo.graphite_base
+  r = make_request(graph_render, request.query_string)
+
+  headers = dict(r.raw.headers)
+  def generate():
+    for chunk in r.raw.stream(decode_content=False):
+      yield chunk
+
+  out = Response(generate(), headers=headers)
+  out.status_code=r.status_code
+
+  return out
+
+def make_request(url, params):
+  request_url = "%s?%s" %( url, params )
+  return requests.get(request_url, stream=True)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==0.12.4
 PyYAML==5.1
 mock==2.0.0
+requests=2.25.1


### PR DESCRIPTION
* fix: for python3 - filter returns iteractor, not list
* add an option to proxy the requests to graphite through leonardo
  - this is useful if leonardo have access to graphite, but it is
    not externally exposed.

themage